### PR TITLE
Use "text/plain" as content-type for Prometheus /metrics endpoint.

### DIFF
--- a/src/onyx/http_query.clj
+++ b/src/onyx/http_query.clj
@@ -445,7 +445,7 @@
                 :body (serialize result)}
                (= "/metrics" (:uri request))
                {:status (or status 200)
-                :headers {"Content-Type" (serializer-name content-type)}
+                :headers {"Content-Type" "text/plain"}
                 :body result}
                :else
                {:status (or status 200)


### PR DESCRIPTION
See https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md