### PR TITLE
Remove unnecessary vector in :import causing spec error

### DIFF
--- a/src/onyx/peer_query/job_query.clj
+++ b/src/onyx/peer_query/job_query.clj
@@ -4,7 +4,7 @@
             [onyx.static.planning :refer [find-task]]
             [onyx.peer-query.replica-query :as rq]
             [onyx.extensions :as extensions])
-  (:import [org.apache.zookeeper.KeeperException$NoNodeException]))
+  (:import org.apache.zookeeper.KeeperException$NoNodeException))
 
 (defn ^{:no-doc true} get-log [log]
   (:log (:env log)))


### PR DESCRIPTION
```
-- Spec failed --------------------

  (... ... (... [org.apache.zookeeper.KeeperException$NoNodeException]))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

should satisfy

  simple-symbol?

or

should have additional elements. The next element ":classes" should satisfy

  simple-symbol?
```